### PR TITLE
Feature/parallel threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY ./app /app
 
-CMD ["python", "app.py"]
+ENTRYPOINT ["gunicorn", "app:app", "--workers", "16", "--worker-class", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--bind", "0.0.0.0:8088"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ numpy>=1.26.4
 oci>=2.129.4
 sseclient-py
 pyyaml
-gunicorn
+gunicorn==23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy>=1.26.4
 oci>=2.129.4
 sseclient-py
 pyyaml
+gunicorn


### PR DESCRIPTION
Use gunicorn for serving the app, so it is able to run multiple requests in parallel.
uvicorn is a worker that runs the server, and even if the function is defined as async, the OCI client is not async, so the async endpoint makes a blocking call to OCI, and the requests to the gateway are technically blocking.
With gunicorn, using multiple uvicorn workers (set to 16 here), the gateway can handle up to 16 parallel calls, greatly speeding up applications that are async and depend on this gateway.