### PR TITLE
Update setting.py to fix instance principal

### DIFF
--- a/app/api/setting.py
+++ b/app/api/setting.py
@@ -23,7 +23,9 @@ if AUTH_TYPE == "API_KEY":
     CLIENT_KWARGS.update({'config': OCI_CONFIG})
     CLIENT_KWARGS.update({'signer': signer})
 elif AUTH_TYPE == 'INSTANCE_PRINCIPAL':
+    OCI_CONFIG = {}
     signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+    CLIENT_KWARGS.update({'config': OCI_CONFIG})
     CLIENT_KWARGS.update({'signer': signer})
 
 


### PR DESCRIPTION
https://docs.oracle.com/en-us/iaas/tools/python/2.145.0/api/generative_ai_inference/client/oci.generative_ai_inference.GenerativeAiInferenceClient.html

It looks like there is a required `config` parameter  that must be passed to `GenerativeAiInferenceClient` and when  `AUTH_TYPE = "INSTANCE_PRINCIPAL"` it doesn't seem to get set leading to a failure. 

As seen in https://www.ateam-oracle.com/post/protecting-oci-generative-ai-endpoints-with-web-application-firewall the `config` param can be set to an empty map.

````
[2025-03-04 05:50:50 +0000] [1] [INFO] Starting gunicorn 23.0.0
[2025-03-04 05:50:50 +0000] [1] [INFO] Listening at: http://0.0.0.0:8088 (1)
[2025-03-04 05:50:50 +0000] [1] [INFO] Using worker: uvicorn.workers.UvicornWorker
[2025-03-04 05:50:51 +0000] [7] [INFO] Booting worker with pid: 7
[2025-03-04 05:50:51 +0000] [8] [INFO] Booting worker with pid: 8
[2025-03-04 05:50:51 +0000] [9] [INFO] Booting worker with pid: 9
[2025-03-04 05:50:51 +0000] [10] [INFO] Booting worker with pid: 10
[2025-03-04 05:50:51 +0000] [11] [INFO] Booting worker with pid: 11
[2025-03-04 05:50:51 +0000] [12] [INFO] Booting worker with pid: 12
[2025-03-04 05:50:51 +0000] [13] [INFO] Booting worker with pid: 13
[2025-03-04 05:50:51 +0000] [14] [INFO] Booting worker with pid: 14
[2025-03-04 05:50:51 +0000] [15] [INFO] Booting worker with pid: 15
[2025-03-04 05:50:51 +0000] [16] [INFO] Booting worker with pid: 16
[2025-03-04 05:50:51 +0000] [17] [INFO] Booting worker with pid: 17
[2025-03-04 05:50:52 +0000] [18] [INFO] Booting worker with pid: 18
[2025-03-04 05:50:52 +0000] [19] [INFO] Booting worker with pid: 19
[2025-03-04 05:50:52 +0000] [20] [INFO] Booting worker with pid: 20
[2025-03-04 05:50:52 +0000] [21] [INFO] Booting worker with pid: 21
[2025-03-04 05:50:52 +0000] [22] [INFO] Booting worker with pid: 22
[2025-03-04 05:51:06 +0000] [7] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/gunicorn/arbiter.py", line 608, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.11/site-packages/uvicorn/workers.py", line 75, in init_process
    super().init_process()
  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base.py", line 135, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base.py", line 147, in load_wsgi
    self.wsgi = self.app.wsgi()
                ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
                    ^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
    return self.load_wsgiapp()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
    return util.import_app(self.app_uri)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/gunicorn/util.py", line 370, in import_app
    mod = importlib.import_module(module)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/app.py", line 10, in <module>
    from api.routers import model, chat, embeddings
  File "/app/api/routers/model.py", line 6, in <module>
    from api.models.ocigenai import OCIGenAIModel
  File "/app/api/models/ocigenai.py", line 52, in <module>
    generative_ai_inference_client = oci.generative_ai_inference.GenerativeAiInferenceClient(
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: GenerativeAiInferenceClient.__init__() missing 1 required positional argument: 'config'
````